### PR TITLE
Add simple signup link. Fixes #19

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -244,6 +244,16 @@
                 </a>
             </div>
         </section>
+        <section class="row content-wrapper signup">
+            <div class="container">
+                <h4 class="heading--tertiary">Interested?</h4>
+                <p>
+                    Alternatively, if your interested in Codidact and want to be notified as things progress, send an
+                    email to subscribe to our
+                    <a class="subscribe" href="mailto:announcements-subscribe@codidact.org">mailing list</a>
+                </p>
+            </div>
+        </section>
         <footer class="footer row is-full-width">
             <img src="assets/img/logo-codidact-white.svg" class="footer__logo" alt="Codidact logo" width="170" />
             <p class="tagline">The open source Q&A platform.</p>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -71,4 +71,5 @@ section {
 @import "sections/get-involved.scss";
 @import "sections/what-is-codidact.scss";
 @import "sections/community-first.scss";
+@import "sections/signup.scss";
 @import "sections/footer.scss";

--- a/src/styles/sections/signup.scss
+++ b/src/styles/sections/signup.scss
@@ -1,0 +1,13 @@
+.signup {
+    .container {
+        max-width: 400px;
+        margin: 0 auto;
+    }
+
+    .heading--tertiary {
+        text-align: center;
+        margin-bottom: 40px;
+    }
+
+    margin-bottom: 120px;
+}


### PR DESCRIPTION
Fixes #19

The signup link is a mailto anchor tag, sending a message to the supplied email will automatically signup the sender for our mailing list.
To be replaced by a PHP form in the future. This is a minimum viable implementation as a result

Add styles for signup section by centering text
Add small change to text for signup
added margin-bottom to space out the signup row