### PR TITLE
added new github sponsors

### DIFF
--- a/dist/donations.html
+++ b/dist/donations.html
@@ -114,8 +114,12 @@
         <section class="row content-wrapper is-full-width donors">
           <div>
 	    <p>We thank the many generous donors who support The Codidact Foundation and the network of communities at codidact.com, including:</p>
-	    <h3 class="heading--secondary">Ongoing</h3>
-	    <p><a href="https://github.com/codidact">Github sponsor:</a> Shog9</p>
+	    <h3 class="heading--secondary"><a href="https://github.com/codidact">Github sponsors</a> (ongoing support)</h3>
+	    <ul>
+	      <li>Shog9</li>
+	      <li>samliew</li>
+	      <li>Alexei000</li>
+	    </ul>
 	    <h3 class="heading--secondary">2022</h3>
 	    <table>
 	      <tr><th>Donor</th><th>Optional Message</th></tr>


### PR DESCRIPTION
We've gained two GitHub sponsors since the initial version of the donations page, so updating to add them. There are no new public Stripe donors to add.

I did `npm run build` per the readme but that didn't cause any other files to be modified. Maybe that's only if I change CSS? I only changed body text on the donations page.