### PR TITLE
Add CI for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 on:
   pull_request:
     types: [opened, synchronize]
+name: Lint pull request
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
This PR adds linting capabilities for all PRs. This means we can check whether the PR is compliant with linting requirements in the README directly via a GitHub actions status.