### PR TITLE
Sigma is treasurer, not secretrary

### DIFF
--- a/dist/leadership.html
+++ b/dist/leadership.html
@@ -213,7 +213,7 @@
                     </header>
                     <h4 class="card__heading">Sigma</h4>
                     <p class="card__text">
-                        Sigma is co-Group Leader for User Documentation and the official Secretary for the Codidact Foundation. She handles the Foundation's finances and makes sure our user docs are up-to-date.
+                        Sigma is co-Group Leader for User Documentation and the official Treasurer for the Codidact Foundation. She handles the Foundation's finances and makes sure our user docs are up-to-date.
                     </p>
                 </a>
                                 <a


### PR DESCRIPTION
Noticed this while I was answering a question about Codidact leadership -- we listed both Mithrandir24601 and Sigma as secretary, but Sigma is treasurer.  Text-only change, one word.