### PR TITLE
we don't sell data or cooprate with LLMs; let's say so

### DIFF
--- a/dist/donations.html
+++ b/dist/donations.html
@@ -130,6 +130,11 @@
 	      <li>fplk</li>
 	    </ul>
 	    <h3 class="heading--secondary">Direct donors (with optional messages)</h3>
+	    <p>2024</p>
+	    <ul>
+	      <li>President James K. Polk: Firstly, this is an important effort, and secondly, it's been well-executed. I hope it continues to grow.</li>
+	      <li>Iizuki</li>
+	    </ul>
 	    <p>2023</p>
 	    <ul>
 	      <li>Iizuki</li>

--- a/dist/index.html
+++ b/dist/index.html
@@ -148,6 +148,9 @@
                     We welcome beginners and experts alike, and aim to empower communities of learners and teachers.
                     We're funded by seeking donations, not by paywalls, and work with individual communities that want to join us.
                 </p>
+		<p><br/></p> <!-- no paragraph spacing without this -->
+		<p>We put people first. We will never sell your data, and we do not cooperate with AI companies collecting data to train LLMs.</p>
+		</p>
                 <h3 class="heading--secondary">The Codidact Foundation</h3>
                 <p>
                     Our non-profit organization, The Codidact Foundation, is made up of people directly from our communities, located in countries all over the world. We're incorporated in the United Kingdom as a Community Interest Company (CIC), with plans to become a Charitable Incorporated Organisation (CIO) in the future.


### PR DESCRIPTION
Added a brief paragraph to the "community first" section about (not) selling data or doing LLMs.

I'm not sure why the donation change is showing up here.  That's already live.  If I've fumbled something with `git` I'm happy to fix it but don't know what I might have done...
