### PR TITLE
An attempt at making GitHub Pages auto-deployable

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -18,11 +18,13 @@ jobs:
           node-version: 22.13.1
       - run: npm ci
       - run: npm run build
+      # https://github.com/actions/upload-pages-artifact?tab=readme-ov-file#usage
       - name: Upload build artifacts
         id: upload
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist/
+  # https://github.com/actions/deploy-pages?tab=readme-ov-file#usage
   deploy:
     environment:
       name: github-pages

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,34 @@
+name: Publish to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build landing page
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 22.13.1
+      - run: npm ci
+      - run: npm run build
+      - name: Upload build artifacts
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy landing page
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -29,6 +29,9 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy landing page
         id: deploy

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -9,7 +9,6 @@ jobs:
   build:
     name: Build landing page
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -20,15 +19,17 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Upload build artifacts
+        id: upload
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist/
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deploy.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Deploy landing page
+        id: deploy
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Not sure if it'll work out of the box as I haven't done this in a while - let's take a look. Will add a preview action for PRs as a followup if it works. Important: this job [needs appropriate permissions](https://github.com/actions/deploy-pages?tab=readme-ov-file#security-considerations) to run (can't check myself).

P.S. If / when this succeeds, we will be able to safely drop the `gh-pages` branch